### PR TITLE
Allow more configuration

### DIFF
--- a/lib/passport-trademe/strategy.js
+++ b/lib/passport-trademe/strategy.js
@@ -16,14 +16,26 @@ var util = require('util')
 function Strategy(options, verify) {
 
 	options = options || {};
-	options.requestTokenURL = options.requestTokenURL || 'https://secure.trademe.co.nz/Oauth/RequestToken';
-	options.accessTokenURL = options.accessTokenURL || 'https://secure.trademe.co.nz/Oauth/AccessToken';
-	options.userAuthorizationURL = options.userAuthorizationURL || 'https://secure.trademe.co.nz/Oauth/Authorize';
 	options.sessionKey = options.sessionKey || 'oauth:trademe';
-	
+	options.apiVersion = options.apiVersion || 'v1';
+
+	options.apiHost = options.apiHost || 'https://api.trademe.co.nz';
+	options.oAuthBaseUrl = options.oAuthBaseUrl || 'https://secure.trademe.co.nz/Oauth';
+
+	if(options.sandbox) {
+		options.apiHost = options.apiHost.replace('trademe.co.nz', 'tmsandbox.co.nz');
+		options.oAuthBaseUrl = options.oAuthBaseUrl.replace('trademe.co.nz', 'tmsandbox.co.nz');
+	}
+
+	options.requestTokenURL = options.requestTokenURL || options.oAuthBaseUrl + '/RequestToken';
+	options.accessTokenURL = options.accessTokenURL || options.oAuthBaseUrl + '/AccessToken';
+	options.userAuthorizationURL = options.userAuthorizationURL || options.oAuthBaseUrl + '/Authorize';
+
 	OAuthStrategy.call(this, options, verify);
 	this.name = 'trademe';
-	
+
+	this._options = options;
+
 	this._skipExtendedUserProfile = (options.skipExtendedUserProfile === undefined) ? false : options.skipExtendedUserProfile;
 }
 
@@ -52,32 +64,6 @@ Strategy.prototype.authenticate = function(req, options) {
 /**
  * Retrieve member profile from Trademe.
  *
- * http://api.trademe.co.nz/v1/Member/Profile.json
- * { "Id": 5690 }
- *
- * http://api.trademe.co.nz/v1/Member/5690/Profile.json
- * { 
- * "Biography" : "",
- * "DateRemoved" : "/Date(0)/",
- * "FirstName" : "Karol",
- * "IsEnabled" : true,
- * "Member" : { "DateAddressVerified" : "/Date(0)/",
- *     "DateJoined" : "/Date(946551600000)/",
- *     "FeedbackCount" : 20,
- *     "IsAddressVerified" : false,
- *     "IsAuthenticated" : true,
- *     "IsDealer" : false,
- *     "MemberId" : 5690,
- *     "Nickname" : "silverhalides",
- *     "Suburb" : "Wellington City",
- *     "UniqueNegative" : 0,
- *     "UniquePositive" : 20
- *   },
- * "Occupation" : "",
- * "Photo" : "http://images.trademe.co.nz/photoserver/profiles/member_profile5690v1",
- * "Quote" : ""
- * }
- *
  * @param {String} token
  * @param {String} tokenSecret
  * @param {Object} params
@@ -87,37 +73,78 @@ Strategy.prototype.authenticate = function(req, options) {
 Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
 	
 	var profile = { provider: 'trademe' };
+
+	var that = this;
 	
 	if (!this._skipExtendedUserProfile) {
 		
-		var url = 'http://api.trademe.co.nz/v1/Member/Profile.json';
+		var url = this._options.apiHost + '/' + this._options.apiVersion + '/MyTradeMe/Summary.json';
 		this._oauth.get(url, token, tokenSecret, function (err, body, res) {
 
 			if (err) { return done(new InternalOAuthError('failed to fetch member profile', err)); }
 			
-			var object = {};
+			var myTradeMeObject = {};
 			
 			try {
-				object = JSON.parse(body);
+				myTradeMeObject = JSON.parse(body);
 			} catch (e) {
-				object = null;
-				done(e);
+				myTradeMeObject = null;
+				return done(e);
 			}
 			
-			if (object === undefined || object === null) {
-				console.log('Unfortunately the object is non-existent');
-			} else {
-				profile.id = object.Id;
-				profile._raw = body;
-				profile._json = object;
-				
-				done(null, profile);
+			if (myTradeMeObject === undefined || myTradeMeObject === null) {
+				return done(new Error('Unfortunately the myTradeMeObject is non-existent'));
 			} 
+
+			if(!myTradeMeObject.MemberId) {
+				return done(new Error('No MemberId returned'));
+			}
+
+			const memberUrl = that._options.apiHost + '/' + that._options.apiVersion + '/Member/' + myTradeMeObject.MemberId +'/Profile.json';
+		
+			that._oauth.get(memberUrl, token, tokenSecret, function (err, body, res) {
+
+				if (err) { return done(new InternalOAuthError('failed to fetch member profile', err)); }
+
+				var object = {};
+			
+				try {
+					object = JSON.parse(body);
+				} catch (e) {
+					object = null;
+					return done(e);
+				}
+				
+				if (object === undefined || object === null) {
+					return done(new Error('Unfortunately the object is non-existent'));
+				} 
+
+				profile.id = object.Member.MemberId.toString();
+				profile.emails = [
+					{
+						value: myTradeMeObject.Email
+					}
+				];
+				profile.username = myTradeMeObject.Nickname
+				profile.displayName = [
+					myTradeMeObject.FirstName || '',
+					myTradeMeObject.LastName || ''
+				].join(' ').trim();
+				profile.photos = object.Photo ? [
+					{
+						value: object.Photo
+					} 
+				] : [];
+				profile.member = object;
+				profile.mine = myTradeMeObject;
+
+				return done(null, profile);
+			});
 		});
 	} else {
 		profile.id = params.user_id;
 		
-		done(null, profile);
+		return done(null, profile);
 	}
 }
 


### PR DESCRIPTION
Add configuration:
- `apiVersion` Version of the api, default `v1`
- `apiHost` Host to use to contact the api, default `https://api.trademe.co.nz`
- `oAuthBaseUrl` Host to use while authenticating, default `https://secure.trademe.co.nz/Oauth`
- `sandbox` Replace `trademe.co.nz` with `tmsandbox.co.nz` in `apiHost` and `oAuthBaseUrl`

Also retrieves the user profile id using http://developer.trademe.co.nz/api-reference/my-trade-me-methods/retrieve-your-profile-information/ and then http://developer.trademe.co.nz/api-reference/membership-methods/retrieve-member-profile/ 

The output is then also aligned with strategies like `passport-twitter` and `passport-facebook`:

```
{
  "provider": "trademe",
  "id": "<removed>",
  "emails": [
    {
      "value": "<removed>"
    }
  ],
  "username": "fabiancook",
  "displayName": "Fabian Cook",
  "photos": [
    {
      "value": "https://images.tmsandbox.co.nz/images/kiwi130.gif"
    }
  ],
  "member": {},
  "mine": {}
}
```

The result from the two requests are also passed back in `member` and `mine`

We could probably clean this up a bit, but its a start
